### PR TITLE
test: coreEval code without swingset

### DIFF
--- a/contract/test/core-eval.test.ts
+++ b/contract/test/core-eval.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @file lightweight test for our coreEval code, using contractExports and such
+ */
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { makeIssuerKit } from '@agoric/ertp';
+import { makePromiseSpace } from '@agoric/vats';
+import { makeWellKnownSpaces } from '@agoric/vats/src/core/utils.js';
+import type { AmountKeywordRecord, ZoeService } from '@agoric/zoe';
+import type { Instance } from '@agoric/zoe/src/zoeService/utils.js';
+import { setUpZoeForTest } from '@agoric/zoe/tools/setup-zoe.js';
+import { withAmountUtils } from '@agoric/zoe/tools/test-utils.js';
+import { E, passStyleOf } from '@endo/far';
+import {
+  startStakeManagement,
+  type StkBootPowers,
+} from '../../deploy/src/start-contract.js';
+import * as contractExports from '../stake.contract.js';
+import { commonSetup } from './fusdc-tools/supports.js';
+import { executeOffer } from './supports.js';
+import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
+import type { PortfolioConfig } from '../typeGuards.js';
+import { Fail } from '@endo/errors';
+
+const { entries } = Object;
+
+test('coreEval code without swingset', async (t) => {
+  const { bootstrap, utils } = await commonSetup(t);
+  const { agoricNamesAdmin } = bootstrap;
+  const wk = await makeWellKnownSpaces(agoricNamesAdmin);
+  const log = () => {}; // console.log
+  const { produce, consume } = makePromiseSpace({ log });
+  const powers = { produce, consume, ...wk } as StkBootPowers;
+  // XXX type of zoe from setUpZoeForTest is any???
+  const { zoe: zoeAny, bundleAndInstall } = await setUpZoeForTest();
+  const zoe: ZoeService = zoeAny;
+  const BLD = withAmountUtils(makeIssuerKit('BLD'));
+
+  {
+    t.log('produce bootstrap entries from commonSetup()');
+    for (const [n, v] of entries(bootstrap)) {
+      switch (n) {
+        case 'timer':
+          produce.chainTimerService.resolve(v);
+          break;
+        case 'storage':
+          produce.chainStorage.resolve(v.rootNode);
+          break;
+        default:
+          produce[n].resolve(v);
+      }
+    }
+
+    const IST = await (async () => {
+      const issuer = await E(zoe).getFeeIssuer();
+      const brand = await E(issuer).getBrand();
+      return harden({ issuer, brand });
+    })();
+
+    for (const [name, { brand, issuer }] of entries({ BLD, IST })) {
+      t.log('produce brand, issuer for', name);
+      wk.brand.produce[name].resolve(brand);
+      wk.issuer.produce[name].resolve(issuer);
+    }
+
+    t.log('produce installation using test bundle');
+    wk.installation.produce.StkC.resolve(bundleAndInstall(contractExports));
+
+    t.log('produce startUpgradable');
+    produce.startUpgradable.resolve(
+      ({ label, installation, issuerKeywordRecord, privateArgs, terms }) =>
+        E(zoe).startInstance(
+          installation,
+          issuerKeywordRecord,
+          terms,
+          privateArgs,
+          label,
+        ),
+    );
+  }
+
+  t.log('invoke coreEval');
+  await t.notThrowsAsync(
+    startStakeManagement(powers, { options: { assetInfo: [], chainInfo: {} } }),
+  );
+
+  const { agoricNames } = bootstrap;
+  const instance = (await E(agoricNames).lookup(
+    'instance',
+    'StkC',
+  )) as Instance<contractExports.StartFn>;
+  t.log('found StkC instance', instance);
+  t.is(passStyleOf(instance), 'remotable');
+
+  // XXX lots of code duplicated from stake.contract.test.ts
+  const offerArgs: PortfolioConfig = {
+    osmosis: { freq: 'daily', onReceipt: ['stake'], onRewards: ['restake'] },
+  };
+  const give: AmountKeywordRecord = harden({
+    Fee: BLD.units(10),
+    Retainer: BLD.units(50),
+  });
+  const publicInvitationMaker = 'makeStakingPortfolio';
+  const spec: OfferSpec = {
+    id: 'msp-1',
+    invitationSpec: { source: 'contract', instance, publicInvitationMaker },
+    offerArgs,
+    proposal: { give },
+  };
+  t.log(spec);
+  const myBLD = BLD.issuer.makeEmptyPurse();
+  myBLD.deposit(BLD.mint.mintPayment(BLD.units(100)));
+  /** @param {Brand} b */
+  const providePurse = (b) =>
+    b === BLD.brand ? myBLD : Fail`no purse for ${b}`;
+  const { vowTools } = utils;
+  const { result, payouts } = await executeOffer(
+    zoe,
+    vowTools.when,
+    spec,
+    providePurse,
+  );
+});

--- a/contract/test/fusdc-tools/supports.ts
+++ b/contract/test/fusdc-tools/supports.ts
@@ -158,7 +158,8 @@ export const commonSetup = async (t: ExecutionContext<any>) => {
     transfer: transferMiddleware,
   });
   const timer = buildZoeManualTimer(t.log);
-  const marshaller = makeFakeBoard().getPublishingMarshaller();
+  const board = makeFakeBoard();
+  const marshaller = board.getPublishingMarshaller();
   const storage = makeFakeStorageKit(
     'fun', // Fast USDC Node
   );
@@ -246,6 +247,7 @@ export const commonSetup = async (t: ExecutionContext<any>) => {
       agoricNames,
       agoricNamesAdmin,
       bankManager,
+      board,
       timer,
       localchain,
       cosmosInterchainService,

--- a/deploy/src/start-contract.js
+++ b/deploy/src/start-contract.js
@@ -10,24 +10,20 @@ import { E } from '@endo/far';
  * @import {CosmosChainInfo, Denom, DenomDetail} from '@agoric/orchestration';
  * @import {StorageNode} from '@agoric/internal/src/lib-chainStorage.js';
  * @import {StartFn, StkCTerms} from '../../contract/stake.contract.js';
+ * @import {TimerService} from '@agoric/time';
  */
 
 const trace = makeTracer('start StkC', true);
 
 /**
- * @param {BootstrapPowers & {
- *   consume: { chainStorage: StorageNode },
- *   installation: {
- *     consume: {
- *       StkC: Installation<StartFn>;
- *     };
- *   };
- *   instance: {
- *     produce: {
- *       StkC: Producer<Instance<StartFn>>;
- *     };
- *   };
- * }} powers
+ * @typedef {BootstrapPowers & PromiseSpaceOf<{
+ *     chainStorage: StorageNode;
+ *     chainTimerService: TimerService;
+ *   }> & {
+ *   installation: PromiseSpaceOf<{ StkC: Installation<StartFn>}>;
+ *   instance: PromiseSpaceOf<{ StkC: Producer<Instance<StartFn>> }>;
+ * }} StkBootPowers
+ * @param {StkBootPowers} powers
  * @param {{
  *   options: {
  *     chainInfo: Record<string, CosmosChainInfo>;

--- a/deploy/test/utils/drivers.ts
+++ b/deploy/test/utils/drivers.ts
@@ -1,35 +1,31 @@
 /* eslint-disable jsdoc/require-param */
-import { Fail } from '@endo/errors';
 import { type Amount } from '@agoric/ertp';
-import { NonNullish } from '@agoric/internal';
 import { Offers } from '@agoric/inter-protocol/src/clientSupport.js';
 import { SECONDS_PER_MINUTE } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
-import {
-  slotToBoardRemote,
-  unmarshalFromVstorage,
-} from '@agoric/internal/src/marshal.js';
+import { oracleBrandFeedName } from '@agoric/inter-protocol/src/proposals/utils.js';
+import { NonNullish } from '@agoric/internal';
+import { unmarshalFromVstorage } from '@agoric/internal/src/marshal.js';
 import {
   type FakeStorageKit,
   slotToRemotable,
 } from '@agoric/internal/src/storage-test-utils.js';
-import { oracleBrandFeedName } from '@agoric/inter-protocol/src/proposals/utils.js';
-
-import {
-  type AgoricNamesRemotes,
-  boardSlottingMarshaller,
-} from '@agoric/vats/tools/board-utils.js';
+import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
 import type {
   CurrentWalletRecord,
   SmartWallet,
   UpdateRecord,
 } from '@agoric/smart-wallet/src/smartWallet.js';
-import type { WalletFactoryStartResult } from '@agoric/vats/src/core/startWalletFactory.js';
-import type { OfferSpec } from '@agoric/smart-wallet/src/offers.js';
-import type { TimerService } from '@agoric/time';
 import type { OfferMaker } from '@agoric/smart-wallet/src/types.js';
 import type { RunUtils } from '@agoric/swingset-vat/tools/run-utils.js';
-import { makeMarshal } from '@endo/marshal';
-import type { InvitationDetails } from '@agoric/zoe';
+import type { TimerService } from '@agoric/time';
+import type { WalletFactoryStartResult } from '@agoric/vats/src/core/startWalletFactory.js';
+import {
+  type AgoricNamesRemotes,
+  boardSlottingMarshaller,
+} from '@agoric/vats/tools/board-utils.js';
+import type { Instance, InvitationDetails } from '@agoric/zoe';
+import { Fail } from '@endo/errors';
+import type { ERef } from '@endo/far';
 import type { SwingsetTestKit } from './support.js';
 
 // XXX SwingsetTestKit would simplify this

--- a/deploy/test/utils/support.ts
+++ b/deploy/test/utils/support.ts
@@ -8,8 +8,16 @@ import { basename, join } from 'path';
 import { inspect } from 'util';
 
 import type { TypedPublished } from '@agoric/client-utils';
+import type { CoreEvalSDKType } from '@agoric/cosmic-proto/swingset/swingset.js';
+import { computronCounter } from '@agoric/cosmic-swingset/src/computron-counter.js';
 import { buildSwingset } from '@agoric/cosmic-swingset/src/launch-chain.js';
+import {
+  defaultBeansPerVatCreation,
+  defaultBeansPerXsnapComputron,
+} from '@agoric/cosmic-swingset/src/sim-params.js';
 import { makeHelpers } from '@agoric/cosmic-swingset/tools/inquisitor.mjs';
+import type { Amount, Brand } from '@agoric/ertp';
+import type { EconomyBootstrapPowers } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
 import {
   BridgeId,
   makeTracer,
@@ -22,43 +30,31 @@ import { makeFakeStorageKit } from '@agoric/internal/src/storage-test-utils.js';
 import { krefOf } from '@agoric/kmarshal';
 import { makeTestAddress } from '@agoric/orchestration/tools/make-test-address.js';
 import { initSwingStore } from '@agoric/swing-store';
-import { loadSwingsetConfigFile } from '@agoric/swingset-vat';
-import { makeSlogSender } from '@agoric/telemetry';
-import { TimeMath, type Timestamp } from '@agoric/time';
-import { fakeLocalChainBridgeTxMsgHandler } from '@agoric/vats/tools/fake-bridge.js';
-import { Fail } from '@endo/errors';
-
-import type { Amount, Brand } from '@agoric/ertp';
 import type {
   EndoZipBase64Bundle,
   ManagerType,
   SwingSetConfig,
 } from '@agoric/swingset-vat';
+import { loadSwingsetConfigFile } from '@agoric/swingset-vat';
+import type { SwingsetController } from '@agoric/swingset-vat/src/controller/controller.js';
 import {
   makeRunUtils,
   type RunHarness,
   type RunUtils,
 } from '@agoric/swingset-vat/tools/run-utils.js';
+import { makeSlogSender } from '@agoric/telemetry';
+import { TimeMath, type Timestamp } from '@agoric/time';
+import type { BridgeHandler, IBCDowncallMethod, IBCMethod } from '@agoric/vats';
+import type { BootstrapRootObject } from '@agoric/vats/src/core/lib-boot.js';
 import {
   boardSlottingMarshaller,
   slotToBoardRemote,
 } from '@agoric/vats/tools/board-utils.js';
-
+import { fakeLocalChainBridgeTxMsgHandler } from '@agoric/vats/tools/fake-bridge.js';
+import { Fail } from '@endo/errors';
+import type { EProxy, ERef } from '@endo/eventual-send';
 import type { ExecutionContext as AvaT } from 'ava';
-
-import type { CoreEvalSDKType } from '@agoric/cosmic-proto/swingset/swingset.js';
-import { computronCounter } from '@agoric/cosmic-swingset/src/computron-counter.js';
-import {
-  defaultBeansPerVatCreation,
-  defaultBeansPerXsnapComputron,
-} from '@agoric/cosmic-swingset/src/sim-params.js';
-import type { EconomyBootstrapPowers } from '@agoric/inter-protocol/src/proposals/econ-behaviors.js';
-import type { SwingsetController } from '@agoric/swingset-vat/src/controller/controller.js';
-import type { BridgeHandler, IBCDowncallMethod, IBCMethod } from '@agoric/vats';
-import type { BootstrapRootObject } from '@agoric/vats/src/core/lib-boot.js';
-import type { EProxy } from '@endo/eventual-send';
 import { FileSystemCache, NodeFetchCache } from 'node-fetch-cache';
-import { tmpdir } from 'node:os';
 import { icaMocks, protoMsgMockMap, protoMsgMocks } from './ibc/mocks.js';
 
 const trace = makeTracer('BSTSupport', false);


### PR DESCRIPTION
A quick test for `start-contract.js` without bootstrapping everything with swingset.

serves as a regression test for the `portfolioFee` terms Issuer vs. Brand problem.

drive-by: a fix for `yarn lint:types` in `deploy/`